### PR TITLE
Allow composition

### DIFF
--- a/src/LTDBeget/sphinx/configurator/ConfigurationFactory.php
+++ b/src/LTDBeget/sphinx/configurator/ConfigurationFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LTDBeget\sphinx\configurator;
+
+use LTDBeget\sphinx\configurator\deserializers\ArrayDeserializer;
+use LTDBeget\sphinx\configurator\deserializers\JsonDeserializer;
+use LTDBeget\sphinx\configurator\deserializers\PlainDeserializer;
+use LTDBeget\sphinx\enums\eVersion;
+
+class ConfigurationFactory
+{
+    /**
+     * @param string   $plainData
+     * @param eVersion $version
+     *
+     * @return Configuration
+     * @throws \Hoa\Ustring\Exception
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \LogicException
+     * @throws \InvalidArgumentException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\DeserializeException
+     * @throws \LTDBeget\sphinx\SyntaxErrorException
+     * @throws \BadMethodCallException
+     * @throws \LTDBeget\sphinx\informer\exceptions\DocumentationSourceException
+     * @throws \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public static function fromString(string $plainData, eVersion $version): Configuration
+    {
+        return PlainDeserializer::deserialize($plainData, new Configuration($version));
+    }
+
+    /**
+     * @param array    $plainData
+     * @param eVersion $version
+     *
+     * @return Configuration
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \LogicException
+     * @throws \InvalidArgumentException
+     * @throws \BadMethodCallException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\DeserializeException
+     * @throws \Symfony\Component\Yaml\Exception\ParseException
+     * @throws \LTDBeget\sphinx\informer\exceptions\DocumentationSourceException
+     */
+    public static function fromArray(array $plainData, eVersion $version): Configuration
+    {
+        return ArrayDeserializer::deserialize($plainData, new Configuration($version));
+    }
+
+    /**
+     * @param string   $plainData
+     * @param eVersion $version
+     *
+     * @return Configuration
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \LogicException
+     * @throws \InvalidArgumentException
+     * @throws \BadMethodCallException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\DeserializeException
+     * @throws \LTDBeget\sphinx\informer\exceptions\DocumentationSourceException
+     * @throws \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public static function fromJson(string $plainData, eVersion $version): Configuration
+    {
+        return JsonDeserializer::deserialize($plainData, new Configuration($version));
+    }
+}

--- a/src/LTDBeget/sphinx/configurator/ConfigurationHelper.php
+++ b/src/LTDBeget/sphinx/configurator/ConfigurationHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LTDBeget\sphinx\configurator;
+
+use LTDBeget\sphinx\configurator\configurationEntities\sections\Source;
+
+class ConfigurationHelper
+{
+    /**
+     * @param Configuration $configuration
+     *
+     * @param string        $name
+     * @param string|null   $inheritanceName
+     *
+     * @return \LTDBeget\sphinx\configurator\configurationEntities\sections\Source
+     */
+    public static function createSource(Configuration $configuration, string $name, string $inheritanceName = null
+    ): Source {
+        $source = new Source($configuration, $name, $inheritanceName);
+        $configuration->addSource($source);
+
+        return $source;
+    }
+}

--- a/src/LTDBeget/sphinx/configurator/ConfigurationHelper.php
+++ b/src/LTDBeget/sphinx/configurator/ConfigurationHelper.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace LTDBeget\sphinx\configurator;
 
+use LTDBeget\sphinx\configurator\configurationEntities\sections\Common;
+use LTDBeget\sphinx\configurator\configurationEntities\sections\Index;
+use LTDBeget\sphinx\configurator\configurationEntities\sections\Indexer;
+use LTDBeget\sphinx\configurator\configurationEntities\sections\Searchd;
 use LTDBeget\sphinx\configurator\configurationEntities\sections\Source;
+use LTDBeget\sphinx\configurator\exceptions\ConfigurationException;
+use LTDBeget\sphinx\enums\eSection;
 
 class ConfigurationHelper
 {
@@ -15,12 +21,86 @@ class ConfigurationHelper
      * @param string|null   $inheritanceName
      *
      * @return \LTDBeget\sphinx\configurator\configurationEntities\sections\Source
+     * @throws \LogicException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \InvalidArgumentException
      */
-    public static function createSource(Configuration $configuration, string $name, string $inheritanceName = null
+    public static function createSource(
+        Configuration $configuration,
+        string $name,
+        string $inheritanceName = null
     ): Source {
         $source = new Source($configuration, $name, $inheritanceName);
         $configuration->addSource($source);
 
         return $source;
+    }
+
+    /**
+     * @param Configuration $configuration
+     *
+     * @param string        $name
+     * @param string|null   $inheritanceName
+     *
+     * @return \LTDBeget\sphinx\configurator\configurationEntities\sections\Index
+     * @throws \LogicException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \InvalidArgumentException
+     */
+    public static function createIndex(Configuration $configuration, string $name, string $inheritanceName = null
+    ): Index {
+        $indexDefinition = new Index($configuration, $name, $inheritanceName);
+        $configuration->addIndex($indexDefinition);
+
+        return $indexDefinition;
+    }
+
+    /**
+     * @param Configuration $configuration
+     *
+     * @return \LTDBeget\sphinx\configurator\configurationEntities\sections\Indexer
+     */
+    public static function getOrCreateIndexer($configuration): Indexer
+    {
+        if (!$configuration->hasIndexer()) {
+            $configuration->setIndexer(new Indexer($configuration));
+        }
+
+        return $configuration->getIndexer();
+    }
+
+    /**
+     * @param Configuration $configuration
+     *
+     * @return \LTDBeget\sphinx\configurator\configurationEntities\sections\Searchd
+     */
+    public static function getOrCreateSearchd($configuration): Searchd
+    {
+        if (!$configuration->hasSearchd()) {
+            $configuration->setSearchd(new Searchd($configuration));
+        }
+
+        return $configuration->getSearchd();
+    }
+
+    /**
+     * @param Configuration $configuration
+     *
+     * @return \LTDBeget\sphinx\configurator\configurationEntities\sections\Common
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     */
+    public static function getOrCreateCommon($configuration): Common
+    {
+        $section = eSection::COMMON();
+        if (!$configuration->isAllowedSection($section)) {
+            $version = $configuration->getVersion();
+            throw new ConfigurationException("Sphinx of version {$version} does't have section {$section}");
+        }
+
+        if (!$configuration->hasCommon()) {
+            $configuration->setCommon(new Common($configuration));
+        }
+
+        return $configuration->getCommon();
     }
 }

--- a/src/LTDBeget/sphinx/configurator/ConfigurationSerializer.php
+++ b/src/LTDBeget/sphinx/configurator/ConfigurationSerializer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LTDBeget\sphinx\configurator;
+
+use LTDBeget\sphinx\configurator\serializers\ArraySerializer;
+use LTDBeget\sphinx\configurator\serializers\JsonSerializer;
+use LTDBeget\sphinx\configurator\serializers\PlainSerializer;
+
+class ConfigurationSerializer
+{
+    private $configuration;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @return string
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     */
+    public function toString(): string
+    {
+        return PlainSerializer::serialize($this->configuration);
+    }
+
+    /**
+     * @return string
+     * @throws \LogicException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \InvalidArgumentException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     */
+    public function toJson(): string
+    {
+        return JsonSerializer::serialize($this->configuration);
+    }
+
+    /**
+     * @return array
+     * @throws \InvalidArgumentException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\SectionException
+     * @throws \LogicException
+     * @throws \LTDBeget\sphinx\configurator\exceptions\ConfigurationException
+     */
+    public function toArray(): array
+    {
+        return ArraySerializer::serialize($this->configuration);
+    }
+}

--- a/src/LTDBeget/sphinx/configurator/configurationEntities/base/Definition.php
+++ b/src/LTDBeget/sphinx/configurator/configurationEntities/base/Definition.php
@@ -216,7 +216,7 @@ abstract class Definition extends Section
     {
         switch ($this->getType()) {
             case eSection::INDEX:
-                $iterator = $this->getConfiguration()->iterateIndex();
+                $iterator = $this->getConfiguration()->iterateIndexes();
                 break;
             case eSection::SOURCE:
                 $iterator = $this->getConfiguration()->iterateSources();

--- a/src/LTDBeget/sphinx/configurator/configurationEntities/base/Definition.php
+++ b/src/LTDBeget/sphinx/configurator/configurationEntities/base/Definition.php
@@ -219,7 +219,7 @@ abstract class Definition extends Section
                 $iterator = $this->getConfiguration()->iterateIndex();
                 break;
             case eSection::SOURCE:
-                $iterator = $this->getConfiguration()->iterateSource();
+                $iterator = $this->getConfiguration()->iterateSources();
                 break;
             default:
                 throw new LogicException("Unknown type {$this->getType()}");

--- a/src/LTDBeget/sphinx/configurator/configurationEntities/sections/Index.php
+++ b/src/LTDBeget/sphinx/configurator/configurationEntities/sections/Index.php
@@ -52,7 +52,7 @@ class Index extends Definition
             }
         } while($index->isHasInheritance());
 
-        foreach ($this->getConfiguration()->iterateSource() as $source) {
+        foreach ($this->getConfiguration()->iterateSources() as $source) {
             if($source->getName() === $source_name) {
                 return $source;
             }

--- a/src/LTDBeget/sphinx/configurator/deserializers/ArrayDeserializer.php
+++ b/src/LTDBeget/sphinx/configurator/deserializers/ArrayDeserializer.php
@@ -99,19 +99,19 @@ final class ArrayDeserializer
 
         switch ($type) {
             case eSection::INDEXER:
-                $section = $this->objectConfiguration->getIndexer();
+                $section = ConfigurationHelper::getOrCreateIndexer($this->objectConfiguration);
                 break;
             case eSection::SEARCHD:
-                $section = $this->objectConfiguration->getSearchd();
+                $section = ConfigurationHelper::getOrCreateSearchd($this->objectConfiguration);
                 break;
             case eSection::COMMON:
-                $section = $this->objectConfiguration->getCommon();
+                $section = ConfigurationHelper::getOrCreateCommon($this->objectConfiguration);
                 break;
             case eSection::SOURCE:
                 $section = ConfigurationHelper::createSource($this->objectConfiguration, $name, $inheritance);
                 break;
             case eSection::INDEX:
-                $section = $this->objectConfiguration->createIndex($name, $inheritance);
+                $section = ConfigurationHelper::createIndex($this->objectConfiguration, $name, $inheritance);
                 break;
             default:
                 throw new DeserializeException('Unknown section type');

--- a/src/LTDBeget/sphinx/configurator/deserializers/ArrayDeserializer.php
+++ b/src/LTDBeget/sphinx/configurator/deserializers/ArrayDeserializer.php
@@ -9,6 +9,7 @@ namespace LTDBeget\sphinx\configurator\deserializers;
 
 use LTDBeget\sphinx\configurator\Configuration;
 use LTDBeget\sphinx\configurator\configurationEntities\base\Section;
+use LTDBeget\sphinx\configurator\ConfigurationHelper;
 use LTDBeget\sphinx\configurator\exceptions\DeserializeException;
 use LTDBeget\sphinx\enums\base\eOption;
 use LTDBeget\sphinx\enums\eSection;
@@ -107,10 +108,10 @@ final class ArrayDeserializer
                 $section = $this->objectConfiguration->getCommon();
                 break;
             case eSection::SOURCE:
-                $section = $this->objectConfiguration->addSource($name, $inheritance);
+                $section = ConfigurationHelper::createSource($this->objectConfiguration, $name, $inheritance);
                 break;
             case eSection::INDEX:
-                $section = $this->objectConfiguration->addIndex($name, $inheritance);
+                $section = $this->objectConfiguration->createIndex($name, $inheritance);
                 break;
             default:
                 throw new DeserializeException('Unknown section type');

--- a/src/LTDBeget/sphinx/configurator/serializers/ArraySerializer.php
+++ b/src/LTDBeget/sphinx/configurator/serializers/ArraySerializer.php
@@ -8,6 +8,7 @@
 namespace LTDBeget\sphinx\configurator\serializers;
 
 use LTDBeget\sphinx\configurator\Configuration;
+use LTDBeget\sphinx\configurator\ConfigurationHelper;
 
 /**
  * Class ArraySerializer
@@ -93,7 +94,7 @@ class ArraySerializer
      */
     private function serializeIndex()
     {
-        foreach ($this->objectConfiguration->iterateIndex() as $index) {
+        foreach ($this->objectConfiguration->iterateIndexes() as $index) {
             $this->arrayConfiguration[] = $index->toArray();
         }
     }
@@ -105,8 +106,8 @@ class ArraySerializer
      */
     private function serializeIndexer()
     {
-        if ($this->objectConfiguration->isHasIndexer()) {
-            $this->arrayConfiguration[] = $this->objectConfiguration->getIndexer()->toArray();
+        if ($this->objectConfiguration->hasIndexer()) {
+            $this->arrayConfiguration[] = ConfigurationHelper::getOrCreateIndexer($this->objectConfiguration)->toArray();
         }
     }
 
@@ -117,8 +118,8 @@ class ArraySerializer
      */
     private function serializeSearchhd()
     {
-        if ($this->objectConfiguration->isHasSearchd()) {
-            $this->arrayConfiguration[] = $this->objectConfiguration->getSearchd()->toArray();
+        if ($this->objectConfiguration->hasSearchd()) {
+            $this->arrayConfiguration[] = ConfigurationHelper::getOrCreateSearchd($this->objectConfiguration)->toArray();
         }
     }
 
@@ -130,8 +131,8 @@ class ArraySerializer
      */
     private function serializeCommon()
     {
-        if ($this->objectConfiguration->isHasCommon()) {
-            $this->arrayConfiguration[] = $this->objectConfiguration->getCommon()->toArray();
+        if ($this->objectConfiguration->hasCommon()) {
+            $this->arrayConfiguration[] = ConfigurationHelper::getOrCreateCommon($this->objectConfiguration)->toArray();
         }
     }
 }

--- a/src/LTDBeget/sphinx/configurator/serializers/ArraySerializer.php
+++ b/src/LTDBeget/sphinx/configurator/serializers/ArraySerializer.php
@@ -80,7 +80,7 @@ class ArraySerializer
      */
     private function serializeSource()
     {
-        foreach ($this->objectConfiguration->iterateSource() as $source) {
+        foreach ($this->objectConfiguration->iterateSources() as $source) {
             $this->arrayConfiguration[] = $source->toArray();
         }
     }

--- a/src/LTDBeget/sphinx/configurator/serializers/PlainSerializer.php
+++ b/src/LTDBeget/sphinx/configurator/serializers/PlainSerializer.php
@@ -21,7 +21,7 @@ final class PlainSerializer
      * @var string
      */
     private $string = '';
-    
+
     /**
      * @var Configuration
      */
@@ -72,7 +72,7 @@ final class PlainSerializer
      */
     private function serializeSources()
     {
-        foreach ($this->object->iterateSource() as $source) {
+        foreach ($this->object->iterateSources() as $source) {
             $this->string .= (string) $source;
         }
     }

--- a/src/LTDBeget/sphinx/configurator/serializers/PlainSerializer.php
+++ b/src/LTDBeget/sphinx/configurator/serializers/PlainSerializer.php
@@ -8,6 +8,7 @@
 namespace LTDBeget\sphinx\configurator\serializers;
 
 use LTDBeget\sphinx\configurator\Configuration;
+use LTDBeget\sphinx\configurator\ConfigurationHelper;
 
 /**
  * Class PlainSerializer
@@ -82,7 +83,7 @@ final class PlainSerializer
      */
     private function serializeIndexes()
     {
-        foreach ($this->object->iterateIndex() as $index) {
+        foreach ($this->object->iterateIndexes() as $index) {
             $this->string .= (string) $index;
         }
     }
@@ -92,8 +93,8 @@ final class PlainSerializer
      */
     private function serializeIndexer()
     {
-        if ($this->object->isHasIndexer()) {
-            $this->string .= (string) $this->object->getIndexer();
+        if ($this->object->hasIndexer()) {
+            $this->string .= (string)ConfigurationHelper::getOrCreateIndexer($this->object);
         }
     }
 
@@ -102,8 +103,8 @@ final class PlainSerializer
      */
     private function serializeSearchd()
     {
-        if ($this->object->isHasSearchd()) {
-            $this->string .= (string) $this->object->getSearchd();
+        if ($this->object->hasSearchd()) {
+            $this->string .= (string)ConfigurationHelper::getOrCreateSearchd($this->object);
         }
     }
 
@@ -113,8 +114,8 @@ final class PlainSerializer
      */
     private function serializeCommon()
     {
-        if ($this->object->isHasCommon()) {
-            $this->string .= (string) $this->object->getCommon();
+        if ($this->object->hasCommon()) {
+            $this->string .= (string)ConfigurationHelper::getOrCreateCommon($this->object);
         }
     }
 }

--- a/tests/CompositionTest.php
+++ b/tests/CompositionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use LTDBeget\sphinx\configurator\Configuration;
+use LTDBeget\sphinx\enums\eVersion;
+use LTDBeget\sphinx\enums\options\eCommonOption;
+use LTDBeget\sphinx\enums\options\eIndexerOption;
+use LTDBeget\sphinx\enums\options\eIndexOption;
+use LTDBeget\sphinx\enums\options\eSearchdOption;
+use LTDBeget\sphinx\enums\options\eSourceOption;
+
+class CompositionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_support_composition_from_classes()
+    {
+        $version = eVersion::V_2_2_10();
+        $sut = new Configuration($version);
+
+        $sut->setCommon(new Common($sut));
+        $sut->setSearchd(new Searchd($sut));
+        $sut->setIndexer(new Indexer($sut));
+        $sut->addSource(new Source($sut));
+        $sut->addIndex(new Index($sut));
+    }
+}
+
+class Searchd extends \LTDBeget\sphinx\configurator\configurationEntities\sections\Searchd
+{
+    public function __construct(\LTDBeget\sphinx\configurator\Configuration $configuration)
+    {
+        parent::__construct($configuration);
+        $this->addOption(eSearchdOption::CLIENT_TIMEOUT(), '5');
+    }
+}
+
+class Indexer extends \LTDBeget\sphinx\configurator\configurationEntities\sections\Indexer
+{
+    public function __construct(\LTDBeget\sphinx\configurator\Configuration $configuration)
+    {
+        parent::__construct($configuration);
+        $this->addOption(eIndexerOption::MEM_LIMIT(), '256M');
+    }
+}
+
+class Common extends \LTDBeget\sphinx\configurator\configurationEntities\sections\Common
+{
+    public function __construct(\LTDBeget\sphinx\configurator\Configuration $configuration)
+    {
+        parent::__construct($configuration);
+        $this->addOption(eCommonOption::LEMMATIZER_BASE(), '/var/lib/sphinx/dict/');
+    }
+}
+
+class Source extends \LTDBeget\sphinx\configurator\configurationEntities\sections\Source
+{
+    const NAME = 'test';
+
+    public function __construct(\LTDBeget\sphinx\configurator\Configuration $configuration)
+    {
+        $inheritance = null;
+
+        parent::__construct($configuration, self::NAME, $inheritance);
+        $this->addOption(eSourceOption::SQL_QUERY(), 'select * from some_source');
+    }
+}
+
+class Index extends \LTDBeget\sphinx\configurator\configurationEntities\sections\Index
+{
+    public function __construct(\LTDBeget\sphinx\configurator\Configuration $configuration)
+    {
+        $name = 'test';
+        $inheritance = null;
+
+        parent::__construct($configuration, $name, $inheritance);
+        $this->addOption(eIndexOption::SOURCE(), Source::NAME);
+    }
+}

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -136,7 +136,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config = ConfigurationFactory::fromJson((new ConfigurationSerializer($config))->toJson(), eVersion::V_2_2_10());
         $config = ConfigurationFactory::fromString((new ConfigurationSerializer($config))->toString(), eVersion::V_2_2_10());
 
-        $hash = md5((string) $config);
+        $hash = md5((new ConfigurationSerializer($config))->toString());
 
         static::assertEquals($referenceHash, $hash);
     }

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -15,7 +15,6 @@ use LTDBeget\sphinx\enums\options\eIndexOption;
 /**
  * Class ConfiguratorTest
  */
-
 class ConfiguratorTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -129,8 +128,8 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__. '/../sphinx/conf/valid.example.conf';
         $plain_config = file_get_contents($config_path);
 
-        $referenceHash = md5((string)ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10()));
-
+        $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
+        $referenceHash = md5((new ConfigurationSerializer($config))->toString());
 
         $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
         $config = ConfigurationFactory::fromArray((new ConfigurationSerializer($config))->toArray(), eVersion::V_2_2_10());
@@ -169,7 +168,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        $hash = md5((string) $config);
+        $hash = md5((new ConfigurationSerializer($config))->toString());
 
         /** @noinspection SpellCheckingInspection */
         static::assertEquals('f26517544c25d8ef994622380a0afbe9', $hash);
@@ -182,7 +181,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
 
         $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
 
-        $hash = md5((string) $config);
+        $hash = md5((new ConfigurationSerializer($config))->toString());
 
         /** @noinspection SpellCheckingInspection */
         static::assertEquals('2b841aab6bf02ea10f3fdec82eee0872', $hash);

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -5,9 +5,9 @@
  * @time: 5:58
  */
 
-
-
 use LTDBeget\sphinx\configurator\Configuration;
+use LTDBeget\sphinx\configurator\ConfigurationFactory;
+use LTDBeget\sphinx\configurator\ConfigurationHelper;
 use LTDBeget\sphinx\enums\eVersion;
 use LTDBeget\sphinx\enums\options\eIndexOption;
 
@@ -26,8 +26,8 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__. '/../sphinx/conf/valid.example.conf';
         $plain_config = file_get_contents($config_path);
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        Configuration::fromString($plain_config, eVersion::V_2_1_8());
-        
+        ConfigurationFactory::fromString($plain_config, eVersion::V_2_1_8());
+
     }
 
     /**
@@ -39,7 +39,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__ . '/../sphinx/conf/invalid/inheritance_source.conf';
         $plain_config = file_get_contents($config_path);
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        Configuration::fromString($plain_config, eVersion::V_2_1_8());
+        ConfigurationFactory::fromString($plain_config, eVersion::V_2_1_8());
     }
 
     /**
@@ -51,7 +51,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__ . '/../sphinx/conf/invalid/inheritance_index.conf';
         $plain_config = file_get_contents($config_path);
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        Configuration::fromString($plain_config, eVersion::V_2_1_8());
+        ConfigurationFactory::fromString($plain_config, eVersion::V_2_1_8());
     }
 
     /**
@@ -63,7 +63,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__ . '/../sphinx/conf/invalid/duplicate_source_name.conf';
         $plain_config = file_get_contents($config_path);
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        Configuration::fromString($plain_config, eVersion::V_2_1_8());
+        ConfigurationFactory::fromString($plain_config, eVersion::V_2_1_8());
     }
 
     /**
@@ -75,7 +75,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__ . '/../sphinx/conf/invalid/duplicate_index_name.conf';
         $plain_config = file_get_contents($config_path);
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        Configuration::fromString($plain_config, eVersion::V_2_1_8());
+        ConfigurationFactory::fromString($plain_config, eVersion::V_2_1_8());
     }
 
     /**
@@ -87,7 +87,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__ . '/../sphinx/conf/invalid/comments_hell.conf';
         $plain_config = file_get_contents($config_path);
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        Configuration::fromString($plain_config, eVersion::V_2_1_8());
+        ConfigurationFactory::fromString($plain_config, eVersion::V_2_1_8());
     }
 
     /**
@@ -97,7 +97,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
     public function testWrongName()
     {
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        (new Configuration(eVersion::V_2_2_10()))->addSource('SOME WRONG NAME');
+        ConfigurationHelper::createSource(new Configuration(eVersion::V_2_2_10()), 'SOME WRONG NAME');
     }
 
     /**
@@ -107,7 +107,8 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
     public function testWrongInheritance()
     {
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        (new Configuration(eVersion::V_2_2_10()))->addSource('valid_name', 'S o m&^ e shit');
+        ConfigurationHelper::createSource(new Configuration(eVersion::V_2_2_10()), 'valid_name',
+            'S o m&^ e shit');
     }
 
     /**
@@ -117,7 +118,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
     public function testAddPermanentlyRemovedOption()
     {
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
-        $index = (new Configuration(eVersion::V_2_2_10()))->addIndex('valid_name');
+        $index = (new Configuration(eVersion::V_2_2_10()))->createIndex('valid_name');
         /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
         $index->addOption(eIndexOption::CHARSET_TYPE(), "utf-8");
     }
@@ -127,13 +128,13 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__. '/../sphinx/conf/valid.example.conf';
         $plain_config = file_get_contents($config_path);
 
-        $referenceHash = md5((string) Configuration::fromString($plain_config, eVersion::V_2_2_10()));
+        $referenceHash = md5((string)ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10()));
 
 
-        $config = Configuration::fromString($plain_config, eVersion::V_2_2_10());
-        $config = Configuration::fromArray($config->toArray(), eVersion::V_2_2_10());
-        $config = Configuration::fromJson($config->toJson(), eVersion::V_2_2_10());
-        $config = Configuration::fromString( (string) $config, eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromArray($config->toArray(), eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromJson($config->toJson(), eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromString((string)$config, eVersion::V_2_2_10());
 
         $hash = md5((string) $config);
 
@@ -145,11 +146,11 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__. '/../sphinx/conf/valid.example.conf';
         $plain_config = file_get_contents($config_path);
 
-        $config = Configuration::fromString($plain_config, eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
         foreach($config->iterateIndex() as $section) {
             $section->delete();
         }
-        foreach($config->iterateSource() as $section) {
+        foreach($config->iterateSources() as $section) {
             $section->delete();
         }
 
@@ -168,7 +169,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         }
 
         $hash = md5((string) $config);
-        
+
         /** @noinspection SpellCheckingInspection */
         static::assertEquals('f26517544c25d8ef994622380a0afbe9', $hash);
     }
@@ -178,14 +179,14 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__. '/../sphinx/conf/unicode.conf';
         $plain_config = file_get_contents($config_path);
 
-        $config = Configuration::fromString($plain_config, eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
 
         $hash = md5((string) $config);
 
         /** @noinspection SpellCheckingInspection */
         static::assertEquals('2b841aab6bf02ea10f3fdec82eee0872', $hash);
     }
-    
+
     public function testCheckGetInheritance()
     {
         $configuration = new Configuration(eVersion::V_2_2_10());
@@ -193,8 +194,8 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $parent_name = 'source1';
         $child_name = 'source2';
 
-        $parent = $configuration->addSource($parent_name);
-        $child = $configuration->addSource($child_name, $parent_name);
+        $parent = ConfigurationHelper::createSource($configuration, $parent_name);
+        $child = ConfigurationHelper::createSource($configuration, $child_name, $parent_name);
 
         static::assertSame($child->getInheritance(), $parent);
     }
@@ -207,8 +208,8 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase
         $parent_name = 'source1';
         $child_name = 'source2';
 
-        $parent = $configuration->addSource($parent_name);
-        $child = $configuration->addSource($child_name, $parent_name);
+        $parent = ConfigurationHelper::createSource($configuration, $parent_name);
+        $child = ConfigurationHelper::createSource($configuration, $child_name, $parent_name);
 
         $parent->delete();
 

--- a/tests/InformerTest.php
+++ b/tests/InformerTest.php
@@ -52,7 +52,7 @@ class InformerTest extends PHPUnit_Framework_TestCase
         $config_path = __DIR__. '/../sphinx/conf/valid.example.conf';
         $plain_config = file_get_contents($config_path);
         $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
-        foreach($config->iterateIndex() as $section) {
+        foreach($config->iterateIndexes() as $section) {
             foreach($section->iterateOptions() as $option) {
                 $option->getInfo();
             }
@@ -63,20 +63,20 @@ class InformerTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        if($config->isHasIndexer()) {
-            foreach($config->getIndexer()->iterateOptions() as $option) {
+        if($config->hasIndexer()) {
+            foreach(Configuration::getIndexer($config)->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }
 
-        if($config->isHasSearchd()) {
-            foreach($config->getSearchd()->iterateOptions() as $option) {
+        if($config->hasSearchd()) {
+            foreach(Configuration::getSearchd($config)->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }
 
-        if($config->isHasCommon()) {
-            foreach($config->getCommon()->iterateOptions() as $option) {
+        if($config->hasCommon()) {
+            foreach(Configuration::getCommon($config)->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }

--- a/tests/InformerTest.php
+++ b/tests/InformerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use LTDBeget\sphinx\configurator\ConfigurationFactory;
+use LTDBeget\sphinx\configurator\ConfigurationHelper;
 use LTDBeget\sphinx\enums\eSection;
 use LTDBeget\sphinx\enums\eVersion;
 use LTDBeget\sphinx\enums\options\eCommonOption;
@@ -64,19 +65,19 @@ class InformerTest extends PHPUnit_Framework_TestCase
         }
 
         if($config->hasIndexer()) {
-            foreach(Configuration::getIndexer($config)->iterateOptions() as $option) {
+            foreach(ConfigurationHelper::getOrCreateIndexer($config)->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }
 
         if($config->hasSearchd()) {
-            foreach(Configuration::getSearchd($config)->iterateOptions() as $option) {
+            foreach(ConfigurationHelper::getOrCreateSearchd($config)->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }
 
         if($config->hasCommon()) {
-            foreach(Configuration::getCommon($config)->iterateOptions() as $option) {
+            foreach(ConfigurationHelper::getOrCreateCommon($config)->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }

--- a/tests/InformerTest.php
+++ b/tests/InformerTest.php
@@ -1,5 +1,6 @@
 <?php
-use LTDBeget\sphinx\configurator\Configuration;
+
+use LTDBeget\sphinx\configurator\ConfigurationFactory;
 use LTDBeget\sphinx\enums\eSection;
 use LTDBeget\sphinx\enums\eVersion;
 use LTDBeget\sphinx\enums\options\eCommonOption;
@@ -50,13 +51,13 @@ class InformerTest extends PHPUnit_Framework_TestCase
     {
         $config_path = __DIR__. '/../sphinx/conf/valid.example.conf';
         $plain_config = file_get_contents($config_path);
-        $config = Configuration::fromString($plain_config, eVersion::V_2_2_10());
+        $config = ConfigurationFactory::fromString($plain_config, eVersion::V_2_2_10());
         foreach($config->iterateIndex() as $section) {
             foreach($section->iterateOptions() as $option) {
                 $option->getInfo();
             }
         }
-        foreach($config->iterateSource() as $section) {
+        foreach($config->iterateSources() as $section) {
             foreach($section->iterateOptions() as $option) {
                 $option->getInfo();
             }


### PR DESCRIPTION
My original idea was to provide ability to composite sphinx configuration from classes instead of declaring it line by line.
You can view example in `CompositionTest`.

Sorry, I introduced many public api changes. Some of them was must — e.g. `add*` should accept instance, not create one. Some of them was not — e.g. renames of `iterate*`.

Also, I separated some (de)serialization logic, because concerns solving logic should be separated.

I hope you understood my original idea besides introducing major api changes.
Please tell me what do you think about such a big rewrite.
Also I leaved some `todo` comments with my thoughts, please comment them too.